### PR TITLE
Remove redundant keywords from io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -135,9 +135,6 @@
     "readme": "https://github.com/arteck/ioBroker.xsense/blob/master/README.md",
     "loglevel": "info",
     "keywords": [
-      "iobroker",
-      "adapter",
-      "smart home",
       "xsense",
       "x-sense",
       "XSense Bridge",


### PR DESCRIPTION
This PR fixes
👀 [W168] "common.keywords" should not contain "iobroker, adapter, smart home" [io-package.json](https://github.com/arteck/ioBroker.xsense/blob/master/io-package.json)
