### PR TITLE
Delay MQTT startup until device paths are ready

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ class XSenseAdapter extends utils.Adapter {
         this.xsenseClient = null;
         this.deviceController = null;
         this._requestInterval = null;
+        this._devicePathsReady = false;
         this.houseCache = null; // Cache für Haus-Objekte (für MQTT-Topic-Auflösung)
 
         /** Bereits beim MQTT-Broker subscribed Topics – verhindert Duplikate */
@@ -55,10 +56,6 @@ class XSenseAdapter extends utils.Adapter {
             }
 
             // MQTT-Verbindung (unabhängig vom Cloud-Login)
-            if (this.config.useMqttServer && loginGo) {
-                await this.connectToMQTT();
-            }
-
             if (!loginGo) {
                 this.log.warn('[XSense] Login übersprungen – Konfiguration unvollständig');
                 return;
@@ -78,6 +75,10 @@ class XSenseAdapter extends utils.Adapter {
             if (this.xsenseClient) {
                 this.setState('info.connection', true, true);
                 await this.startIntervall();
+
+                if (this.config.useMqttServer) {
+                    await this.connectToMQTT();
+                }
             }
         } catch (err) {
             this.setState('info.connection', false, true);
@@ -203,6 +204,7 @@ class XSenseAdapter extends utils.Adapter {
 
             // In ioBroker-States schreiben
             await this.json2iob.parseHouses(this.namespace, this.xsenseClient.houses);
+            this._devicePathsReady = true;
 
             this.setState('info.connection', true, true);
             this.log.debug(`[XSense] datenVerarbeiten abgeschlossen (MQTT-aktiv: ${mqttActive}, force: ${forceFullRefresh})`);
@@ -582,7 +584,12 @@ class XSenseAdapter extends utils.Adapter {
                     }
                 }
 
-                // Fallback: Legacy SBS50-Parsing
+                // Fallback: Legacy SBS50-Parsing erst nutzen, wenn die Hauspfade bekannt sind
+                if (!this._devicePathsReady) {
+                    this.log.debug(`[XSense] Legacy-MQTT-Nachricht verworfen bis Gerätepfade bereit sind: ${topic}`);
+                    return;
+                }
+
                 const payloadStr = payload.toString();
                 const slashIdx = topic.indexOf('/');
                 const topicSuffix = slashIdx >= 0 ? topic.slice(slashIdx + 1) : topic;

--- a/test/mqttConnection.test.js
+++ b/test/mqttConnection.test.js
@@ -257,6 +257,86 @@ describe('info.MQTT_connection – onReady Fehlerfall', () => {
 });
 
 describe('info.MQTT_connection – externalMqttServerIP Validierung', () => {
+describe('MQTT startup sequencing', () => {
+    it('verbindet MQTT erst nach dem initialen startIntervall', async () => {
+        const calls = [];
+        const adapter = {
+            config: { useMqttServer: true },
+            houseCache: null,
+            log: { info: () => {}, warn: () => {}, error: () => {} },
+            json2iob: {
+                async createStaticDeviceObject() {
+                    calls.push('createStaticDeviceObject');
+                },
+            },
+            async ensureInfoStates() {
+                calls.push('ensureInfoStates');
+            },
+            async setAllAvailableToFalse() {
+                calls.push('setAllAvailableToFalse');
+            },
+            async initSession() {
+                calls.push('initSession');
+                return {};
+            },
+            async startIntervall() {
+                calls.push('startIntervall');
+            },
+            async connectToMQTT() {
+                calls.push('connectToMQTT');
+            },
+            setState() {},
+        };
+
+        async function onReadyCore() {
+            await adapter.ensureInfoStates();
+            await adapter.json2iob.createStaticDeviceObject();
+            await adapter.setAllAvailableToFalse();
+            const xsenseClient = await adapter.initSession();
+
+            if (xsenseClient) {
+                adapter.setState('info.connection', true, true);
+                await adapter.startIntervall();
+
+                if (adapter.config.useMqttServer) {
+                    await adapter.connectToMQTT();
+                }
+            }
+        }
+
+        await onReadyCore();
+        assert.deepEqual(calls, [
+            'ensureInfoStates',
+            'createStaticDeviceObject',
+            'setAllAvailableToFalse',
+            'initSession',
+            'startIntervall',
+            'connectToMQTT',
+        ]);
+    });
+
+    it('verwirft Legacy-Fallback solange die Gerätepfade noch nicht bereit sind', () => {
+        let legacyParseCalled = false;
+        const adapter = {
+            _devicePathsReady: false,
+            log: { debug: () => {} },
+        };
+
+        function handleLegacyFallback(topic, payload) {
+            if (!adapter._devicePathsReady) {
+                adapter.log.debug(`[XSense] Legacy-MQTT-Nachricht verworfen bis Gerätepfade bereit sind: ${topic}`);
+                return;
+            }
+
+            const payloadStr = payload.toString();
+            legacyParseCalled = payloadStr.length >= 0;
+        }
+
+        handleLegacyFallback('homeassistant/binary_sensor/test/state', Buffer.from('{}'));
+        assert.equal(legacyParseCalled, false);
+    });
+});
+
     it('connectToMQTT bricht ab wenn externalMqttServerIP leer ist (exmqtt)', async () => {
         const adapter = createAdapterMock({ connectionType: 'exmqtt', externalMqttServerIP: '' });
         let warningLogged = false;


### PR DESCRIPTION
## Summary
- delay MQTT startup until the initial house/device tree has been loaded into ioBroker
- mark device paths as ready only after parseHouses completes
- ignore legacy fallback messages until the house-aware device paths exist to avoid writes to devices.<bridge>.<device>

## Testing
- node node_modules/mocha/bin/mocha.js --timeout 10000 --exit test/mqttConnection.test.js
- node node_modules/mocha/bin/mocha.js --timeout 10000 --exit test/haTopics.test.js test/messageParse.test.js
- node C:/Users/LuCkEr4eVeR/Documents/Codex/_tmp_npm_runtime/package/bin/npm-cli.js run test:package
- node C:/Users/LuCkEr4eVeR/Documents/Codex/_tmp_npm_runtime/package/bin/npm-cli.js run lint