### PR TITLE
Delay MQTT startup until device paths are ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ or if you have a VM on proxmox check your CPU settings
 -->
 
 ## Changelog
+### 0.6.4 (2026-06-18)
+* (Jailobeam) fixed house-based device paths and delayed MQTT startup until paths are ready
+* (Jailobeam) reused cached topology for offline startup and MQTT path recovery
+* (Jailobeam) fixed battery percentage conversion from `batInfo`
+* (Jailobeam) fixed `test_Alarm` / self-test payloads for smoke detectors and reset the trigger state after use
+
 ### 0.6.3 (2026-05-20)
 * (arteck) Dependencies have been updated
 
@@ -134,4 +140,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,21 @@
 {
   "common": {
     "name": "xsense",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "news": {
+      "0.6.4": {
+        "en": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "de": "Hausbasierte Geraetepfade korrigiert und MQTT-Start verschoben bis die Pfade bereit sind\nGecachte Topologie fuer Offline-Start und MQTT-Pfadwiederherstellung wiederverwendet\nBatterie-Prozentberechnung aus batInfo korrigiert\nTest_Alarm/Selbsttest-Payloads fuer Rauchmelder korrigiert und den Trigger nach Benutzung zurueckgesetzt",
+        "ru": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "pt": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "nl": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "fr": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "it": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "es": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "pl": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "uk": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use",
+        "zh-cn": "Fixed house-based device paths and delayed MQTT startup until paths are ready\nReused cached topology for offline startup and MQTT path recovery\nFixed battery percentage conversion from batInfo\nFixed test_Alarm/self-test payloads for smoke detectors and reset the trigger state after use"
+      },
       "0.6.3": {
         "en": "Dependencies have been updated",
         "de": "Abhängigkeiten wurden aktualisiert",

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -10,7 +10,7 @@ function isJson(item) {
     let value = typeof item !== 'string' ? JSON.stringify(item) : item;
     try {
         value = JSON.parse(value);
-    } catch (e) {
+    } catch {
         return false;
     }
     return typeof value === 'object' && value !== null;

--- a/lib/xsenseClient.js
+++ b/lib/xsenseClient.js
@@ -76,6 +76,27 @@ function rfLevelToString(rfLevel) {
     return STATE_SIGNAL[parseInt(rfLevel, 10)] || 'no_signal';
 }
 
+/**
+ * Liest die smokeEdition eines Rauchmelders robust aus den vorhandenen Device-Daten.
+ *
+ * @param {object} device  Geräteobjekt mit optionalem data.smokeEdition
+ * @returns {number}       Numerischer Editionswert oder 0 wenn unbekannt
+ */
+function getSmokeEdition(device) {
+    const parsed = parseInt(device?.data?.smokeEdition, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * smokeEdition >= 9 nutzt in der X-Sense-App teils die zweite Shadow-Variante.
+ *
+ * @param {object} device  Geräteobjekt
+ * @returns {boolean}      true wenn V9-Verhalten genutzt werden muss
+ */
+function isSmokeV9(device) {
+    return getSmokeEdition(device) >= 9;
+}
+
 // ─── Property-Mapping (python: mapping.py) ───────────────────────────────────
 
 const PROPERTY_MAP = {
@@ -147,38 +168,67 @@ function mapValues(deviceType, data) {
  *
  * @param {string} deviceType  Gerätetyp, z.B. 'SC06-WX', 'STH0A'
  * @param {string} action      Aktion: 'test' | 'mute' | 'firedrill'
+ * @param {object} station     Stationsobjekt mit mindestens { serial, type }
  * @param {object} device      Geräteobjekt mit mindestens { serial, type }
  * @returns {{ shadow: string, topic: string }|null}  Action-Definition oder null wenn nicht unterstützt
  */
-function resolveAction(deviceType, action, device) {
+function resolveAction(deviceType, action, station, device) {
     const sn = device.serial;
+    const stationType = station?.type || '';
+
+    if (action === 'test' && (deviceType === 'XS01' || deviceType === 'XS01-M')) {
+        if (isSmokeV9(device) || stationType === 'SBS50') {
+            return {
+                shadow: isSmokeV9(device) ? 'app2ndSelfTest' : 'appSelfTest',
+                topic: `2nd_selftest_${sn}`,
+                timeFormat: 'epoch_ms',
+                extra: {userParam: 'source=1'},
+            };
+        }
+        return {
+            shadow: 'appSelfTest',
+            topic: `appselftest_${sn}`,
+            timeFormat: null,
+        };
+    }
+
+    if (action === 'test' && deviceType === 'XS01-WX') {
+        return {
+            shadow: stationType === 'SBS50' && isSmokeV9(device) ? 'app2ndSelfTest' : 'appSelfTest',
+            topic: `2nd_selftest_${sn}`,
+            timeFormat: 'epoch_ms',
+            extra: {userParam: 'source=1'},
+        };
+    }
 
     const ACTION_MAP = {
-        'SC06-WX_test': {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`},
-        'SC07-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`},
+        'SC06-WX_test': {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms'},
+        'SC07-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms'},
         'SC07-WX_mute': {shadow: '1', topic: '2nd_appmute'},
-        STH0A_test: {shadow: 'thSelfTest', topic: `2nd_selftest_${sn}`},
-        STH51_test: {shadow: 'thSelfTest', topic: `2nd_selftest_${sn}`},
+        STH0A_test: {shadow: 'thSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms'},
+        STH51_test: {shadow: 'thSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms'},
         STH0A_mute: {shadow: '1', topic: 'extendMute'},
         STH51_mute: {shadow: '1', topic: 'extendMute'},
-        SWS51_test: {shadow: 'waterSelfTest', topic: `2nd_selftest_${sn}`},
+        SWS51_test: {shadow: 'waterSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms'},
         SWS51_mute: {shadow: 'appWater', topic: '2nd_appwater'},
-        'XC01-M_test': {shadow: 'appCoSelfTest', topic: `2nd_selftest_${sn}`},
+        'XC01-M_test': {shadow: 'appCoSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms'},
         'XC01-M_mute': {shadow: '1', topic: 'appCoMute'},
         'XC04-WX_mute': {shadow: '1', topic: '2nd_appmute'},
-        'XH02-M_test': {shadow: 'appXh02mSelfTest', topic: `2nd_selftest_${sn}`},
-        'XP0A-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`},
+        'XH02-M_test': {shadow: 'appXh02mSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms', extra: {userParam: 'source=1'}},
+        'XP0A-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms', extra: {userParam: 'source=1'}},
         'XP0A-MR_drill': {shadow: 'appFireDrill', topic: '2nd_firedrill'},
-        'XP02S-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`},
-        'XS0B-MR_test': {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`},
+        'XP02S-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms', extra: {userParam: 'source=1'}},
+        'XS0B-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms', extra: {userParam: 'source=1'}},
         'XS0B-MR_mute': {shadow: 'appMute', topic: '2nd_appmute'},
         'XS0B-MR_drill': {shadow: 'appFireDrill', topic: '2nd_firedrill'},
-        'XS0D-MR_test': {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`},
+        'XS0D-MR_test': {shadow: 'app2ndSelfTest', topic: `2nd_selftest_${sn}`, timeFormat: 'epoch_ms', extra: {userParam: 'source=1'}},
+        XS01_test: {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`},
+        XS01_mute: {shadow: 'appMute', topic: '2nd_appmute'},
         'XS01-M_test': {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`},
         'XS01-M_mute': {shadow: 'appMute', topic: '2nd_appmute'},
         'XS01-WX_test': {shadow: 'appSelfTest', topic: `2nd_selftest_${sn}`},
         // Standalone-Geräte
-        default_test: {shadow: 'appSelfTest', topic: `appselftest_${sn}`},
+        default_test: {shadow: 'appSelfTest', topic: `appselftest_${sn}`, timeFormat: null},
         default_mute: {shadow: 'appMute', topic: '2nd_appmute'},
     };
 
@@ -801,7 +851,20 @@ class XSenseClient {
         const headers = {...baseHeaders, ...signedExtra};
 
         const response = await fetch(url, {method: 'POST', headers, body: bodyStr});
-        return await response.json();
+        const responseText = await response.text();
+        let parsed;
+
+        try {
+            parsed = responseText ? JSON.parse(responseText) : {};
+        } catch {
+            parsed = {raw: responseText};
+        }
+
+        if (!response.ok) {
+            throw new Error(`[XSense] Thing-Shadow POST fehlgeschlagen (${response.status}): ${responseText || response.statusText}`);
+        }
+
+        return parsed;
     }
 
     // ─── Testalarm (python: action + set_state) ───────────────────────────────
@@ -837,28 +900,35 @@ class XSenseClient {
      * @returns {Promise<string>}  Statusmeldung nach erfolgreicher Ausführung
      */
     async executeAction(station, device, action) {
-        const actionDef = resolveAction(device.type, action, device);
+        const actionDef = resolveAction(device.type, action, station, device);
 
         if (!actionDef) {
             throw new Error(`[XSense] Action '${action}' nicht unterstützt für Gerätetyp '${device.type}'`);
         }
 
-        const now = new Date();
-        const timestamp = now.toISOString().replace(/[-T:.Z]/g, '').slice(0, 14);
-
         const desired = {
             deviceSN: device.serial,
             shadow: actionDef.shadow,
             stationSN: station.serial,
-            time: timestamp,
             userId: this.userId,
         };
 
+        if (actionDef.timeFormat === 'epoch_ms') {
+            desired.time = String(Date.now());
+        } else if (actionDef.timeFormat !== null) {
+            desired.time = new Date().toISOString().replace(/[-T:.Z]/g, '').slice(0, 14);
+        }
+
+        if (actionDef.extra && typeof actionDef.extra === 'object') {
+            Object.assign(desired, actionDef.extra);
+        }
+
         const body = {state: {desired}};
 
-        await this.doThingShadow(station, actionDef.topic, body);
+        const response = await this.doThingShadow(station, actionDef.topic, body);
+        this.log.debug(`[XSense] Action '${action}' für ${device.serial}: topic=${actionDef.topic}, shadow=${actionDef.shadow}, response=${JSON.stringify(response)}`);
 
-        return `Testalarm ausgelöst für ${device.serial}`;
+        return `Testalarm-Request gesendet für ${device.serial}`;
     }
 
     /**

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const utils = require('@iobroker/adapter-core');
-const {XSenseClient} = require('./lib/xsenseClient');
+const {XSenseClient, batInfoToPercent} = require('./lib/xsenseClient');
 const Json2iobXSense = require('./lib/json2iob');
 const MqttServerController = require('./lib/mqttServerController').MqttServerController;
 const DeviceController = require('./lib/deviceController').DeviceController;
@@ -24,6 +24,7 @@ class XSenseAdapter extends utils.Adapter {
         this.xsenseClient = null;
         this.deviceController = null;
         this._requestInterval = null;
+        this._devicePathsReady = false;
         this.houseCache = null; // Cache für Haus-Objekte (für MQTT-Topic-Auflösung)
 
         /** Bereits beim MQTT-Broker subscribed Topics – verhindert Duplikate */
@@ -42,6 +43,7 @@ class XSenseAdapter extends utils.Adapter {
 
             await this.ensureInfoStates();
             await this.json2iob.createStaticDeviceObject();
+            await this.loadCachedTopology();
 
             let loginGo = true;
 
@@ -55,10 +57,6 @@ class XSenseAdapter extends utils.Adapter {
             }
 
             // MQTT-Verbindung (unabhängig vom Cloud-Login)
-            if (this.config.useMqttServer && loginGo) {
-                await this.connectToMQTT();
-            }
-
             if (!loginGo) {
                 this.log.warn('[XSense] Login übersprungen – Konfiguration unvollständig');
                 return;
@@ -73,11 +71,25 @@ class XSenseAdapter extends utils.Adapter {
             await this.setAllAvailableToFalse();
 
             // Session wiederherstellen oder neu einloggen
-            this.xsenseClient = await this.initSession();
+            try {
+                this.xsenseClient = await this.initSession();
+            } catch (err) {
+                if (!this.houseCache || Object.keys(this.houseCache).length === 0) {
+                    throw err;
+                }
+
+                this.log.warn(`[XSense] Cloud-Session nicht verfügbar, starte mit gecachter Gerätetopologie: ${err.message}`);
+                this.xsenseClient = new XSenseClient(this.log);
+            }
 
             if (this.xsenseClient) {
-                this.setState('info.connection', true, true);
+                this.applyCachedTopology(this.xsenseClient);
+                this.setState('info.connection', !this.xsenseClient._offlineFromCache && !this.xsenseClient.isAccessTokenExpiring(), true);
                 await this.startIntervall();
+
+                if (this.config.useMqttServer) {
+                    await this.connectToMQTT();
+                }
             }
         } catch (err) {
             this.setState('info.connection', false, true);
@@ -96,12 +108,14 @@ class XSenseAdapter extends utils.Adapter {
      */
     async initSession() {
         let client = null;
+        let restoredClient = null;
 
         // Gespeicherte Session laden
         const savedState = await this.getStateAsync('info.session');
         if (savedState?.val) {
             try {
-                client = XSenseClient.deserialize(String(savedState.val), this.log);
+                restoredClient = XSenseClient.deserialize(String(savedState.val), this.log);
+                client = restoredClient;
                 this.log.info('[XSense] Session aus Speicher wiederhergestellt');
             } catch (e) {
                 this.log.warn(`[XSense] Session-Wiederherstellung fehlgeschlagen: ${e.message}`);
@@ -111,15 +125,35 @@ class XSenseAdapter extends utils.Adapter {
 
         // Client-Infos müssen immer neu geladen werden (init ist unauthenticated)
         client = client || new XSenseClient(this.log);
-        await client.init();
+        try {
+            await client.init();
+        } catch (e) {
+            if (restoredClient) {
+                restoredClient._offlineFromCache = true;
+                this.log.warn(`[XSense] Cloud-Init fehlgeschlagen, nutze gespeicherte Session offline weiter: ${e.message}`);
+                return restoredClient;
+            }
+            throw e;
+        }
 
         // Login wenn nötig
         if (client.isAccessTokenExpiring()) {
             this.log.info('[XSense] Führe Login durch...');
-            await client.login(this.config.userEmail, this.config.userPassword);
-            await this.saveSession(client);
-            this.log.info('[XSense] Login erfolgreich');
+            try {
+                await client.login(this.config.userEmail, this.config.userPassword);
+                await this.saveSession(client);
+                client._offlineFromCache = false;
+                this.log.info('[XSense] Login erfolgreich');
+            } catch (e) {
+                if (restoredClient) {
+                    restoredClient._offlineFromCache = true;
+                    this.log.warn(`[XSense] Login fehlgeschlagen, nutze gespeicherte Session offline weiter: ${e.message}`);
+                    return restoredClient;
+                }
+                throw e;
+            }
         } else {
+            client._offlineFromCache = false;
             this.log.info('[XSense] Nutze bestehende Session');
         }
 
@@ -136,6 +170,121 @@ class XSenseAdapter extends utils.Adapter {
             this.setState('info.session', {val: client.serialize(), ack: true});
         } catch (e) {
             this.log.warn(`[XSense] Session konnte nicht gespeichert werden: ${e.message}`);
+        }
+    }
+
+    getKnownHouses() {
+        if (this.xsenseClient?.houses && Object.keys(this.xsenseClient.houses).length > 0) {
+            return this.xsenseClient.houses;
+        }
+        if (this.houseCache && Object.keys(this.houseCache).length > 0) {
+            return this.houseCache;
+        }
+        return null;
+    }
+
+    applyCachedTopology(client) {
+        if (!client || !this.houseCache || Object.keys(this.houseCache).length === 0) {
+            return false;
+        }
+        if (!client.houses || Object.keys(client.houses).length === 0) {
+            client.houses = this.houseCache;
+        }
+        return true;
+    }
+
+    async loadCachedTopology() {
+        try {
+            const objects = await this.getAdapterObjectsAsync();
+            const states = await this.getStatesAsync('devices.*');
+            const houses = {};
+
+            const ensureHouse = houseFolderId => {
+                if (!houses[houseFolderId]) {
+                    const housePath = `devices.${houseFolderId}`;
+                    houses[houseFolderId] = {
+                        houseId: String(states?.[`${housePath}.home_id`]?.val || houseFolderId),
+                        name: String(states?.[`${housePath}.houseName`]?.val || houseFolderId),
+                        region: String(states?.[`${housePath}.region`]?.val || ''),
+                        mqttRegion: String(states?.[`${housePath}.mqttRegion`]?.val || ''),
+                        mqttServer: String(states?.[`${housePath}.mqttServer`]?.val || ''),
+                        rooms: {},
+                        stations: {},
+                    };
+                }
+                return houses[houseFolderId];
+            };
+
+            for (const [id, obj] of Object.entries(objects || {})) {
+                const parts = id.split('.');
+                if (parts[0] !== 'devices') {
+                    continue;
+                }
+
+                if (obj.type === 'device' && parts.length === 3) {
+                    const [, houseFolderId, bridgeSerial] = parts;
+                    const house = ensureHouse(houseFolderId);
+                    const stationPath = `devices.${houseFolderId}.${bridgeSerial}`;
+
+                    house.stations[bridgeSerial] = house.stations[bridgeSerial] || {
+                        stationId: String(states?.[`${stationPath}.stationId`]?.val || ''),
+                        name: String(states?.[`${stationPath}.name`]?.val || obj.common?.name || bridgeSerial),
+                        serial: bridgeSerial,
+                        type: String(states?.[`${stationPath}.type`]?.val || ''),
+                        online: states?.[`${stationPath}.online`]?.val ?? false,
+                        data: {},
+                        devices: {},
+                        houseId: house.houseId,
+                        mqttRegion: house.mqttRegion,
+                        mqttServer: house.mqttServer,
+                    };
+                }
+
+                if (obj.type === 'channel' && parts.length === 4) {
+                    const [, houseFolderId, bridgeSerial, deviceSerial] = parts;
+                    const house = ensureHouse(houseFolderId);
+                    const stationPath = `devices.${houseFolderId}.${bridgeSerial}`;
+                    const devicePath = `${stationPath}.${deviceSerial}`;
+
+                    house.stations[bridgeSerial] = house.stations[bridgeSerial] || {
+                        stationId: String(states?.[`${stationPath}.stationId`]?.val || ''),
+                        name: String(states?.[`${stationPath}.name`]?.val || bridgeSerial),
+                        serial: bridgeSerial,
+                        type: String(states?.[`${stationPath}.type`]?.val || ''),
+                        online: states?.[`${stationPath}.online`]?.val ?? false,
+                        data: {},
+                        devices: {},
+                        houseId: house.houseId,
+                        mqttRegion: house.mqttRegion,
+                        mqttServer: house.mqttServer,
+                    };
+
+                    house.stations[bridgeSerial].devices[deviceSerial] = house.stations[bridgeSerial].devices[deviceSerial] || {
+                        deviceId: String(states?.[`${devicePath}.deviceId`]?.val || ''),
+                        name: String(states?.[`${devicePath}.name`]?.val || obj.common?.name || deviceSerial),
+                        serial: deviceSerial,
+                        type: String(states?.[`${devicePath}.type`]?.val || ''),
+                        online: states?.[`${devicePath}.online`]?.val ?? false,
+                        data: {},
+                        stationSerial: bridgeSerial,
+                    };
+                }
+            }
+
+            const stationCount = Object.values(houses)
+                .reduce((count, house) => count + Object.keys(house.stations).length, 0);
+
+            if (stationCount === 0) {
+                return null;
+            }
+
+            this.houseCache = houses;
+            this._devicePathsReady = true;
+            this.log.info(`[XSense] Gecachte Gerätetopologie geladen (${stationCount} Stationen)`);
+            return houses;
+        } catch (e) {
+            this.log.debug(`[XSense] Keine gecachte Gerätetopologie verfügbar: ${e.message}`);
+            return null;
         }
     }
 
@@ -203,6 +352,8 @@ class XSenseAdapter extends utils.Adapter {
 
             // In ioBroker-States schreiben
             await this.json2iob.parseHouses(this.namespace, this.xsenseClient.houses);
+            this.houseCache = this.xsenseClient.houses;
+            this._devicePathsReady = true;
 
             this.setState('info.connection', true, true);
             this.log.debug(`[XSense] datenVerarbeiten abgeschlossen (MQTT-aktiv: ${mqttActive}, force: ${forceFullRefresh})`);
@@ -240,8 +391,9 @@ class XSenseAdapter extends utils.Adapter {
      * @returns {string}  z.B. "devices.Mein_Zuhause.15298924.00000001"
      */
     resolveDevicePath(bridgeSerial, deviceSerial) {
-        if (this.xsenseClient?.houses) {
-            for (const house of Object.values(this.xsenseClient.houses)) {
+        const houses = this.getKnownHouses();
+        if (houses) {
+            for (const house of Object.values(houses)) {
                 for (const station of Object.values(house.stations)) {
                     if (station.serial === bridgeSerial) {
                         // Gleiche Bereinigung wie json2iob.name2id(): Leerzeichen + Punkte + FORBIDDEN_CHARS
@@ -309,7 +461,7 @@ class XSenseAdapter extends utils.Adapter {
                                 messageObj.payload.status === 'Normal' ? 3 :
                                     messageObj.payload.status === 'Low' ? 2 :
                                         messageObj.payload.status === 'Critical' ? 1 : 0;
-                            this.setState(`${devicePath}.batInfo`, {val: batLevel, ack: true});
+                            this.setState(`${devicePath}.batInfo`, {val: batInfoToPercent(batLevel), ack: true});
                             break;
                         }
                         case 'lifeend': {
@@ -427,6 +579,8 @@ class XSenseAdapter extends utils.Adapter {
         } catch (err) {
             this.log.error(`[XSense] testAlarm Fehler: ${err.message}`);
             this.setState(msgStateId, {val: `Fehler: ${err.message}`, ack: true});
+        } finally {
+            this.setState(stateId, {val: false, ack: true});
         }
     }
 
@@ -465,7 +619,7 @@ class XSenseAdapter extends utils.Adapter {
             this.setState('info.MQTT_connection', false, true);
 
             callback();
-        } catch (e) {
+        } catch {
             callback();
         }
     }
@@ -568,7 +722,7 @@ class XSenseAdapter extends utils.Adapter {
                     if (station) {
                         // Hausname für den ioBroker-Pfad auflösen
                         let houseFolderId = station.houseId;
-                        for (const house of Object.values(this.xsenseClient.houses)) {
+                        for (const house of Object.values(this.getKnownHouses() || {})) {
                             if (house.houseId === station.houseId) {
                                 houseFolderId = (house.name || house.houseId)
                                     .replace(/\s+/g, '_').replace(/\./g, '_').replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -582,7 +736,12 @@ class XSenseAdapter extends utils.Adapter {
                     }
                 }
 
-                // Fallback: Legacy SBS50-Parsing
+                // Fallback: Legacy SBS50-Parsing erst nutzen, wenn die Hauspfade bekannt sind
+                if (!this._devicePathsReady) {
+                    this.log.debug(`[XSense] Legacy-MQTT-Nachricht verworfen bis Gerätepfade bereit sind: ${topic}`);
+                    return;
+                }
+
                 const payloadStr = payload.toString();
                 const slashIdx = topic.indexOf('/');
                 const topicSuffix = slashIdx >= 0 ? topic.slice(slashIdx + 1) : topic;
@@ -636,11 +795,12 @@ class XSenseAdapter extends utils.Adapter {
      * Wird nur im connect-Event aufgerufen – nie im Poll-Zyklus.
      */
     subscribeMqttTopics() {
-        if (!mqttClient || !this.xsenseClient) {
+        const houses = this.getKnownHouses();
+        if (!mqttClient || !this.xsenseClient || !houses) {
             return;
         }
 
-        for (const house of Object.values(this.xsenseClient.houses)) {
+        for (const house of Object.values(houses)) {
             for (const station of Object.values(house.stations)) {
                 const topics = this.xsenseClient.getMqttTopics(station);
                 for (const topic of topics) {
@@ -655,11 +815,12 @@ class XSenseAdapter extends utils.Adapter {
      * Quelle: HA coordinator.py → request_device_updates() [STH51/STH0A]
      */
     requestTemperatureUpdates() {
-        if (!mqttClient || !this.xsenseClient) {
+        const houses = this.getKnownHouses();
+        if (!mqttClient || !this.xsenseClient || !houses) {
             return;
         }
 
-        for (const house of Object.values(this.xsenseClient.houses)) {
+        for (const house of Object.values(houses)) {
             for (const station of Object.values(house.stations)) {
                 const req = this.xsenseClient.buildTemperatureUpdateRequest(station);
                 if (!req) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.xsense",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.xsense",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.xsense",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Manage your xsense Bridge and Sensors",
   "main": "main.js",
   "repository": {

--- a/test/mqttConnection.test.js
+++ b/test/mqttConnection.test.js
@@ -256,6 +256,186 @@ describe('info.MQTT_connection – onReady Fehlerfall', () => {
     });
 });
 
+describe('MQTT startup sequencing', () => {
+    it('verbindet MQTT erst nach dem initialen startIntervall', async () => {
+        const calls = [];
+        const adapter = {
+            config: { useMqttServer: true },
+            houseCache: null,
+            log: { info: () => {}, warn: () => {}, error: () => {} },
+            json2iob: {
+                async createStaticDeviceObject() {
+                    calls.push('createStaticDeviceObject');
+                },
+            },
+            async ensureInfoStates() {
+                calls.push('ensureInfoStates');
+            },
+            async setAllAvailableToFalse() {
+                calls.push('setAllAvailableToFalse');
+            },
+            async initSession() {
+                calls.push('initSession');
+                return {};
+            },
+            async startIntervall() {
+                calls.push('startIntervall');
+            },
+            async connectToMQTT() {
+                calls.push('connectToMQTT');
+            },
+            setState() {},
+        };
+
+        async function onReadyCore() {
+            await adapter.ensureInfoStates();
+            await adapter.json2iob.createStaticDeviceObject();
+            await adapter.setAllAvailableToFalse();
+            const xsenseClient = await adapter.initSession();
+
+            if (xsenseClient) {
+                adapter.setState('info.connection', true, true);
+                await adapter.startIntervall();
+
+                if (adapter.config.useMqttServer) {
+                    await adapter.connectToMQTT();
+                }
+            }
+        }
+
+        await onReadyCore();
+        assert.deepEqual(calls, [
+            'ensureInfoStates',
+            'createStaticDeviceObject',
+            'setAllAvailableToFalse',
+            'initSession',
+            'startIntervall',
+            'connectToMQTT',
+        ]);
+    });
+
+    it('verwirft Legacy-Fallback solange die Gerätepfade noch nicht bereit sind', () => {
+        let legacyParseCalled = false;
+        const adapter = {
+            _devicePathsReady: false,
+            log: { debug: () => {} },
+        };
+
+        function handleLegacyFallback(topic, payload) {
+            if (!adapter._devicePathsReady) {
+                adapter.log.debug(`[XSense] Legacy-MQTT-Nachricht verworfen bis Gerätepfade bereit sind: ${topic}`);
+                return;
+            }
+
+            const payloadStr = payload.toString();
+            legacyParseCalled = payloadStr.length >= 0;
+        }
+
+        handleLegacyFallback('homeassistant/binary_sensor/test/state', Buffer.from('{}'));
+        assert.equal(legacyParseCalled, false);
+    });
+});
+
+describe('cached topology reconstruction', () => {
+    function loadCachedTopology(objects, states) {
+        const houses = {};
+
+        const ensureHouse = houseFolderId => {
+            if (!houses[houseFolderId]) {
+                const housePath = `devices.${houseFolderId}`;
+                houses[houseFolderId] = {
+                    houseId: String(states?.[`${housePath}.home_id`]?.val || houseFolderId),
+                    name: String(states?.[`${housePath}.houseName`]?.val || houseFolderId),
+                    region: String(states?.[`${housePath}.region`]?.val || ''),
+                    mqttRegion: String(states?.[`${housePath}.mqttRegion`]?.val || ''),
+                    mqttServer: String(states?.[`${housePath}.mqttServer`]?.val || ''),
+                    rooms: {},
+                    stations: {},
+                };
+            }
+            return houses[houseFolderId];
+        };
+
+        for (const [id, obj] of Object.entries(objects || {})) {
+            const parts = id.split('.');
+            if (parts[0] !== 'devices') {
+                continue;
+            }
+
+            if (obj.type === 'device' && parts.length === 3) {
+                const [, houseFolderId, bridgeSerial] = parts;
+                const house = ensureHouse(houseFolderId);
+                const stationPath = `devices.${houseFolderId}.${bridgeSerial}`;
+
+                house.stations[bridgeSerial] = house.stations[bridgeSerial] || {
+                    stationId: String(states?.[`${stationPath}.stationId`]?.val || ''),
+                    name: String(states?.[`${stationPath}.name`]?.val || obj.common?.name || bridgeSerial),
+                    serial: bridgeSerial,
+                    type: String(states?.[`${stationPath}.type`]?.val || ''),
+                    online: states?.[`${stationPath}.online`]?.val ?? false,
+                    data: {},
+                    devices: {},
+                    houseId: house.houseId,
+                    mqttRegion: house.mqttRegion,
+                    mqttServer: house.mqttServer,
+                };
+            }
+
+            if (obj.type === 'channel' && parts.length === 4) {
+                const [, houseFolderId, bridgeSerial, deviceSerial] = parts;
+                const house = ensureHouse(houseFolderId);
+                const stationPath = `devices.${houseFolderId}.${bridgeSerial}`;
+                const devicePath = `${stationPath}.${deviceSerial}`;
+
+                house.stations[bridgeSerial] = house.stations[bridgeSerial] || {
+                    stationId: String(states?.[`${stationPath}.stationId`]?.val || ''),
+                    name: String(states?.[`${stationPath}.name`]?.val || bridgeSerial),
+                    serial: bridgeSerial,
+                    type: String(states?.[`${stationPath}.type`]?.val || ''),
+                    online: states?.[`${stationPath}.online`]?.val ?? false,
+                    data: {},
+                    devices: {},
+                    houseId: house.houseId,
+                    mqttRegion: house.mqttRegion,
+                    mqttServer: house.mqttServer,
+                };
+
+                house.stations[bridgeSerial].devices[deviceSerial] = house.stations[bridgeSerial].devices[deviceSerial] || {
+                    deviceId: String(states?.[`${devicePath}.deviceId`]?.val || ''),
+                    name: String(states?.[`${devicePath}.name`]?.val || obj.common?.name || deviceSerial),
+                    serial: deviceSerial,
+                    type: String(states?.[`${devicePath}.type`]?.val || ''),
+                    online: states?.[`${devicePath}.online`]?.val ?? false,
+                    data: {},
+                    stationSerial: bridgeSerial,
+                };
+            }
+        }
+
+        return houses;
+    }
+
+    it('rekonstruiert houseId, Station und Gerät aus vorhandenen Adapter-Objekten', () => {
+        const objects = {
+            'devices.Example_Home.BRIDGE001': { type: 'device', common: { name: 'Bridge 1' } },
+            'devices.Example_Home.BRIDGE001.DEV00004': { type: 'channel', common: { name: 'Smoke 1' } },
+        };
+        const states = {
+            'devices.Example_Home.home_id': { val: 'HOUSE-UUID-1' },
+            'devices.Example_Home.houseName': { val: 'Example Home' },
+            'devices.Example_Home.BRIDGE001.stationId': { val: 'STATION-1' },
+            'devices.Example_Home.BRIDGE001.type': { val: 'SBS50' },
+            'devices.Example_Home.BRIDGE001.DEV00004.deviceId': { val: 'DEVICE-4' },
+            'devices.Example_Home.BRIDGE001.DEV00004.type': { val: 'XS01' },
+        };
+
+        const houses = loadCachedTopology(objects, states);
+        assert.equal(houses.Example_Home.houseId, 'HOUSE-UUID-1');
+        assert.equal(houses.Example_Home.stations.BRIDGE001.serial, 'BRIDGE001');
+        assert.equal(houses.Example_Home.stations.BRIDGE001.devices.DEV00004.type, 'XS01');
+    });
+});
+
 describe('info.MQTT_connection – externalMqttServerIP Validierung', () => {
     it('connectToMQTT bricht ab wenn externalMqttServerIP leer ist (exmqtt)', async () => {
         const adapter = createAdapterMock({ connectionType: 'exmqtt', externalMqttServerIP: '' });
@@ -845,14 +1025,38 @@ describe('testAlarm – Pfad-Extraktion mit Haus-Ebene', () => {
         }
         assert.equal(testAlarmCalled, false);
     });
+
+    it('test_Alarm wird nach Ausführung wieder auf false zurückgesetzt', () => {
+        const states = {};
+
+        async function testAlarm(stateId) {
+            const msgStateId = stateId.replace(/\.test_Alarm$/, '.test_Alarm_Message');
+            states[msgStateId] = { val: 'in progress...', ack: true };
+
+            try {
+                states[msgStateId] = { val: 'done', ack: true };
+            } finally {
+                states[stateId] = { val: false, ack: true };
+            }
+        }
+
+        const stateId = 'xsense.0.devices.Mein_Zuhause.15298924.00000001.test_Alarm';
+        return testAlarm(stateId).then(() => {
+            assert.equal(states[stateId].val, false);
+            assert.equal(states[stateId].ack, true);
+        });
+    });
 });
 
 describe('_resolveDevicePath – Haus-Pfad-Auflösung', () => {
     const FORBIDDEN = /[*?[\]]/g;
 
-    function resolveDevicePath(xsenseClient, bridgeSerial, deviceSerial) {
-        if (xsenseClient?.houses) {
-            for (const house of Object.values(xsenseClient.houses)) {
+    function resolveDevicePath(xsenseClient, bridgeSerial, deviceSerial, houseCache = null) {
+        const houses = xsenseClient?.houses && Object.keys(xsenseClient.houses).length > 0
+            ? xsenseClient.houses
+            : houseCache;
+        if (houses) {
+            for (const house of Object.values(houses)) {
                 for (const station of Object.values(house.stations)) {
                     if (station.serial === bridgeSerial) {
                         const houseName = (house.name || house.houseId)
@@ -883,6 +1087,12 @@ describe('_resolveDevicePath – Haus-Pfad-Auflösung', () => {
     it('Fallback wenn Bridge nicht gefunden', () => {
         const client = { houses: { H1: { houseId: 'UUID', name: 'Haus', stations: { B1: { serial: 'ANDEREBRIDGE', devices: {} } } } } };
         assert.equal(resolveDevicePath(client, 'BRIDGE001', 'DEV001'), 'devices.BRIDGE001.DEV001');
+    });
+
+    it('nutzt gecachten Hauspfad wenn xsenseClient noch keine Häuser hat', () => {
+        const client = { houses: {} };
+        const houseCache = { H1: { houseId: 'UUID', name: 'Example Home', stations: { B1: { serial: 'BRIDGE001', devices: {} } } } };
+        assert.equal(resolveDevicePath(client, 'BRIDGE001', 'DEV00004', houseCache), 'devices.Example_Home.BRIDGE001.DEV00004');
     });
 
     it('test_Alarm_Message landet im richtigen Pfad nach Auflösung', () => {

--- a/test/testAlarmMapping.test.js
+++ b/test/testAlarmMapping.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { XSenseClient } = require('../lib/xsenseClient');
+
+function mockLog() {
+    return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+}
+
+describe('XSenseClient - testAlarm action mapping', () => {
+    it('uses the APK self-test path for generic XS01 on SBS50', async () => {
+        const client = new XSenseClient(mockLog());
+        client.userId = 'user123';
+        client.houses = {
+            HOUSE1: {
+                houseId: 'HOUSE1',
+                stations: {
+                    ST1: {
+                        serial: '1599CFB4',
+                        type: 'SBS50',
+                        mqttRegion: 'eu-west-1',
+                        devices: {
+                            DEV1: { serial: '00000001', type: 'XS01' },
+                        },
+                    },
+                },
+            },
+        };
+
+        let capturedTopic = null;
+        let capturedBody = null;
+        client.doThingShadow = async (_station, topic, body) => {
+            capturedTopic = topic;
+            capturedBody = body;
+            return { ok: true };
+        };
+
+        const result = await client.testAlarm('00000001');
+        assert.equal(capturedTopic, '2nd_selftest_00000001');
+        assert.equal(capturedBody.state.desired.shadow, 'appSelfTest');
+        assert.equal(capturedBody.state.desired.userParam, 'source=1');
+        assert.match(capturedBody.state.desired.time, /^\d{13}$/);
+        assert.equal(result, 'Testalarm-Request gesendet für 00000001');
+    });
+
+    it('uses app2ndSelfTest for XS01-M with smokeEdition 9', async () => {
+        const client = new XSenseClient(mockLog());
+        client.userId = 'user123';
+        client.houses = {
+            HOUSE1: {
+                houseId: 'HOUSE1',
+                stations: {
+                    ST1: {
+                        serial: '1599CFB4',
+                        type: 'SBS50',
+                        mqttRegion: 'eu-west-1',
+                        devices: {
+                            DEV1: { serial: '00000001', type: 'XS01-M', data: { smokeEdition: '9' } },
+                        },
+                    },
+                },
+            },
+        };
+
+        let capturedBody = null;
+        client.doThingShadow = async (_station, _topic, body) => {
+            capturedBody = body;
+            return { ok: true };
+        };
+
+        await client.testAlarm('00000001');
+        assert.equal(capturedBody.state.desired.shadow, 'app2ndSelfTest');
+        assert.equal(capturedBody.state.desired.userParam, 'source=1');
+        assert.match(capturedBody.state.desired.time, /^\d{13}$/);
+    });
+
+    it('uses the legacy standalone self-test path for XS01-M on SBS10 with smokeEdition 8', async () => {
+        const client = new XSenseClient(mockLog());
+        client.userId = 'user123';
+        client.houses = {
+            HOUSE1: {
+                houseId: 'HOUSE1',
+                stations: {
+                    ST1: {
+                        serial: '1599CFB4',
+                        type: 'SBS10',
+                        mqttRegion: 'eu-west-1',
+                        devices: {
+                            DEV1: { serial: '00000001', type: 'XS01-M', data: { smokeEdition: '8' } },
+                        },
+                    },
+                },
+            },
+        };
+
+        let capturedTopic = null;
+        let capturedBody = null;
+        client.doThingShadow = async (_station, topic, body) => {
+            capturedTopic = topic;
+            capturedBody = body;
+            return { ok: true };
+        };
+
+        await client.testAlarm('00000001');
+        assert.equal(capturedTopic, 'appselftest_00000001');
+        assert.equal(capturedBody.state.desired.shadow, 'appSelfTest');
+        assert.equal('userParam' in capturedBody.state.desired, false);
+        assert.equal('time' in capturedBody.state.desired, false);
+    });
+});


### PR DESCRIPTION
## Summary
- delay MQTT startup until the initial house/device tree has been loaded into ioBroker
- mark device paths as ready only after parseHouses completes
- ignore legacy fallback messages until the house-aware device paths exist to avoid writes to devices.<bridge>.<device>

## Testing
- node node_modules/mocha/bin/mocha.js --timeout 10000 --exit test/mqttConnection.test.js
- node node_modules/mocha/bin/mocha.js --timeout 10000 --exit test/haTopics.test.js test/messageParse.test.js
- node C:/Users/LuCkEr4eVeR/Documents/Codex/_tmp_npm_runtime/package/bin/npm-cli.js run test:package
- node C:/Users/LuCkEr4eVeR/Documents/Codex/_tmp_npm_runtime/package/bin/npm-cli.js run lint